### PR TITLE
chore(release): bump client to v0.9.2 stable

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 0          // Major version component of the current release
-	VersionMinor = 9          // Minor version component of the current release
-	VersionPatch = 2          // Patch version component of the current release
-	VersionMeta  = "unstable" // Version metadata to append to the version string
+	VersionMajor = 0        // Major version component of the current release
+	VersionMinor = 9        // Minor version component of the current release
+	VersionPatch = 2        // Patch version component of the current release
+	VersionMeta  = "stable" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
bumps the story geth client to 0.9.2 stable