### PR TITLE
[feat] add workflow to attach build artifacts

### DIFF
--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -1,0 +1,53 @@
+name: Build Release Binaries
+
+on:
+  release:
+    types:
+      - created
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+  actions: write
+
+jobs:
+  Timestamp:
+    uses: storyprotocol/gha-workflows/.github/workflows/reusable-timestamp.yml@main
+
+  build:
+    needs: Timestamp
+    name: Build Release Assets
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          [linux-amd64, linux-arm64, darwin-amd64, darwin-arm64]
+          
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.1.5
+
+      - name: Display Go version
+        run: go version
+
+      - name: Display the release tag
+        run: |
+          echo "Release tag: ${{ github.event.release.tag_name }}"
+
+      - name: Set up environment for cross-compilation
+        run: |
+          IFS="-" read -r GOOS GOARCH <<< "${{ matrix.platform }}"
+          output_name=./build/bin/geth-${{ matrix.platform }}
+
+          echo "Building for $GOOS/$GOARCH..."
+          env GOOS=$GOOS GOARCH=$GOARCH go build -o $output_name ./cmd/geth
+
+      - name: Upload binaries and source code to GitHub Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.event.release.tag_name }}
+          file: |
+            ./build/bin/geth-${{ matrix.platform }}
+          file_glob: false

--- a/.github/workflows/ci-ecr.yml
+++ b/.github/workflows/ci-ecr.yml
@@ -1,4 +1,4 @@
-name: Build and Upload geth Binary
+name: Build and Upload geth Binary to ECR
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
PR Notes
1. add a workflow to build and attach the built artifacts to the release page
2. no need to manually craft the url of artifact
3. take advantage of GH storage and data transfer