### PR TITLE
[feat] add checksum for each platform

### DIFF
--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -43,6 +43,10 @@ jobs:
           echo "Building for $GOOS/$GOARCH..."
           env GOOS=$GOOS GOARCH=$GOARCH go build -o $output_name ./cmd/geth
 
+      - name: Calculate checksum
+        run: |
+          sha256sum ./build/bin/geth-${{ matrix.platform }} > ./build/bin/geth-${{ matrix.platform }}.sha256
+
       - name: Upload binaries and source code to GitHub Release
         uses: svenstaro/upload-release-action@v2
         with:
@@ -50,4 +54,5 @@ jobs:
           tag: ${{ github.event.release.tag_name }}
           file: |
             ./build/bin/geth-${{ matrix.platform }}
+            ./build/bin/geth-${{ matrix.platform }}.sha256
           file_glob: false


### PR DESCRIPTION
**CONTEXT**
It is essential to have a checksum for each binary available for public to download from security and best practices perspective.

**PR NOTES**
1. add checksum for reach binary built and push them to the release page