### PR TITLE
bugfix(workflows): fix release checksum upload via file globs

### DIFF
--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -53,6 +53,5 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.event.release.tag_name }}
           file: |
-            ./build/bin/geth-${{ matrix.platform }}
-            ./build/bin/geth-${{ matrix.platform }}.sha256
-          file_glob: false
+            ./build/bin/geth-${{ matrix.platform }}*
+          file_glob: true


### PR DESCRIPTION
Updates the GH release workflow to support uploading of checksums, which is currently broken.

Fixes #35 