### PR TITLE
chore(workflow): pin go v1.22 to s3 upload workflow

### DIFF
--- a/.github/workflows/ci-s3.yml
+++ b/.github/workflows/ci-s3.yml
@@ -36,11 +36,16 @@ jobs:
     strategy:
       matrix:
         platform:
-          [linux-amd64, linux-arm64, darwin-amd64, darwin-arm64, windows-amd64]
+          [linux-amd64, linux-arm64, darwin-amd64, darwin-arm64]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.5
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.0'
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
pins go version 1.22 to the s3 public binary upload to fix incompatibility issues