### PR TITLE
hardfork(ipgraph): add ipgraph precompile contract for theogony

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -138,14 +138,30 @@ var PrecompiledContractsPrague = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{0x12}):       &bls12381MapG1{},
 	common.BytesToAddress([]byte{0x13}):       &bls12381MapG2{},
 	common.BytesToAddress([]byte{0x01, 0x00}): &p256Verify{},
-	common.BytesToAddress([]byte{0x01, 0x01}): &ipGraph{},
+	common.BytesToAddress([]byte{0x01, 0x01}): &ipGraphTheogony{},
 }
 
 var PrecompiledContractsBLS = PrecompiledContractsPrague
 
 var PrecompiledContractsVerkle = PrecompiledContractsPrague
 
+var PrecompiledContractsTheogony = map[common.Address]PrecompiledContract{
+	common.BytesToAddress([]byte{0x1}):        &ecrecover{},
+	common.BytesToAddress([]byte{0x2}):        &sha256hash{},
+	common.BytesToAddress([]byte{0x3}):        &ripemd160hash{},
+	common.BytesToAddress([]byte{0x4}):        &dataCopy{},
+	common.BytesToAddress([]byte{0x5}):        &bigModExp{eip2565: true},
+	common.BytesToAddress([]byte{0x6}):        &bn256AddIstanbul{},
+	common.BytesToAddress([]byte{0x7}):        &bn256ScalarMulIstanbul{},
+	common.BytesToAddress([]byte{0x8}):        &bn256PairingIstanbul{},
+	common.BytesToAddress([]byte{0x9}):        &blake2F{},
+	common.BytesToAddress([]byte{0xa}):        &kzgPointEvaluation{},
+	common.BytesToAddress([]byte{0x01, 0x00}): &p256Verify{},
+	common.BytesToAddress([]byte{0x01, 0x01}): &ipGraphTheogony{},
+}
+
 var (
+	PrecompiledAddressesTheogony  []common.Address
 	PrecompiledAddressesPrague    []common.Address
 	PrecompiledAddressesCancun    []common.Address
 	PrecompiledAddressesBerlin    []common.Address
@@ -173,11 +189,16 @@ func init() {
 	for k := range PrecompiledContractsPrague {
 		PrecompiledAddressesPrague = append(PrecompiledAddressesPrague, k)
 	}
+	for k := range PrecompiledContractsTheogony {
+		PrecompiledAddressesTheogony = append(PrecompiledAddressesTheogony, k)
+	}
 }
 
 // ActivePrecompiles returns the precompiles enabled with the current configuration.
 func ActivePrecompiles(rules params.Rules) []common.Address {
 	switch {
+	case rules.IsStoryTheogony:
+		return PrecompiledAddressesTheogony
 	case rules.IsPrague:
 		return PrecompiledAddressesPrague
 	case rules.IsCancun:

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -44,6 +44,8 @@ type (
 func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
 	var precompiles map[common.Address]PrecompiledContract
 	switch {
+	case evm.chainRules.IsStoryTheogony:
+		precompiles = PrecompiledContractsTheogony
 	case evm.chainRules.IsVerkle:
 		precompiles = PrecompiledContractsVerkle
 	case evm.chainRules.IsPrague:

--- a/core/vm/ipgraph.go
+++ b/core/vm/ipgraph.go
@@ -49,9 +49,7 @@ func (c *ipGraph) RequiredGas(input []byte) uint64 {
 
 	switch {
 	case bytes.Equal(selector, addParentIpSelector):
-		args := input[4:]
-		parentCount := new(big.Int).SetBytes(getData(args, 64, 32))
-		return ipGraphWriteGas * parentCount.Uint64()
+		return ipGraphWriteGas
 	case bytes.Equal(selector, hasParentIpSelector):
 		return ipGraphReadGas * averageParentIpCount
 	case bytes.Equal(selector, getParentIpsSelector):
@@ -566,4 +564,62 @@ func (c *ipGraph) getRoyaltyStackLrp(ipId common.Address, evm *EVM, ipGraphAddre
 		totalRoyalty.Add(totalRoyalty, royalty)
 	}
 	return totalRoyalty
+}
+
+type ipGraphTheogony struct {
+	ipGraph
+}
+
+func (c *ipGraphTheogony) RequiredGas(input []byte) uint64 {
+	// Smart contract function's selector is the first 4 bytes of the input
+	if len(input) < 4 {
+		return intrinsicGas
+	}
+
+	selector := input[:4]
+
+	switch {
+	case bytes.Equal(selector, addParentIpSelector):
+		args := input[4:]
+		parentCount := new(big.Int).SetBytes(getData(args, 64, 32))
+		return ipGraphWriteGas * parentCount.Uint64()
+	case bytes.Equal(selector, hasParentIpSelector):
+		return ipGraphReadGas * averageParentIpCount
+	case bytes.Equal(selector, getParentIpsSelector):
+		return ipGraphReadGas * averageParentIpCount
+	case bytes.Equal(selector, getParentIpsCountSelector):
+		return ipGraphReadGas
+	case bytes.Equal(selector, getAncestorIpsSelector):
+		return ipGraphReadGas * averageAncestorIpCount * 2
+	case bytes.Equal(selector, getAncestorIpsCountSelector):
+		return ipGraphReadGas * averageParentIpCount * 2
+	case bytes.Equal(selector, hasAncestorIpsSelector):
+		return ipGraphReadGas * averageAncestorIpCount * 2
+	case bytes.Equal(selector, setRoyaltySelector):
+		return ipGraphWriteGas
+	case bytes.Equal(selector, getRoyaltySelector):
+		royaltyPolicyKind := new(big.Int).SetBytes(getData(input, 64+4, 32))
+		if royaltyPolicyKind.Cmp(royaltyPolicyKindLAP) == 0 {
+			return ipGraphReadGas * (averageAncestorIpCount * 3)
+		} else if royaltyPolicyKind.Cmp(royaltyPolicyKindLRP) == 0 {
+			return ipGraphReadGas * (averageAncestorIpCount*2 + 2)
+		} else {
+			return intrinsicGas
+		}
+	case bytes.Equal(selector, getRoyaltyStackSelector):
+		royaltyPolicyKind := new(big.Int).SetBytes(getData(input, 32+4, 32))
+		if royaltyPolicyKind.Cmp(royaltyPolicyKindLAP) == 0 {
+			return ipGraphReadGas * (averageParentIpCount + 1)
+		} else if royaltyPolicyKind.Cmp(royaltyPolicyKindLRP) == 0 {
+			return ipGraphReadGas * (averageAncestorIpCount * 2)
+		} else {
+			return intrinsicGas
+		}
+	default:
+		return intrinsicGas
+	}
+}
+
+func (c *ipGraphTheogony) Run(evm *EVM, input []byte) ([]byte, error) {
+	return c.ipGraph.Run(evm, input)
 }


### PR DESCRIPTION
Based on #64. The base branch will be changed automatically to `main` when the PR is merged.

Added `ipgraphTheogony` precompiled contract for Theogony hardfork.