### PR TITLE
fix(ipgraph): only allow using opcode call to invoke write functions

### DIFF
--- a/core/vm/ipgraph.go
+++ b/core/vm/ipgraph.go
@@ -152,6 +152,11 @@ func (c *ipGraph) addParentIp(input []byte, evm *EVM, ipGraphAddress common.Addr
 	}
 
 	log.Info("addParentIp", "input", input)
+
+	if evm.currentPrecompileCallType != CALL {
+		return nil, fmt.Errorf("addParentIp can only be called with CALL, not %v", evm.currentPrecompileCallType)
+	}
+
 	if len(input) < 96 {
 		return nil, fmt.Errorf("input too short for addParentIp")
 	}
@@ -330,6 +335,10 @@ func (c *ipGraph) setRoyalty(input []byte, evm *EVM, ipGraphAddress common.Addre
 	}
 
 	log.Info("setRoyalty", "ipGraphAddress", ipGraphAddress, "input", input)
+	if evm.currentPrecompileCallType != CALL {
+		return nil, fmt.Errorf("setRoyalty can only be called with CALL, not %v", evm.currentPrecompileCallType)
+	}
+
 	if len(input) < 96 {
 		return nil, fmt.Errorf("input too short for setRoyalty")
 	}


### PR DESCRIPTION
only allow using CALL opcode to call write functions of ip-graph "addParentIp()" and "setRoyalty()"

Closes https://github.com/FuzzingLabs/story-audit-monorepo/issues/9