### PR TITLE
fix(core/vm): add malleability check for secp256r1 signature

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -21,8 +21,9 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
+
+	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
@@ -1279,11 +1280,12 @@ func (c *p256Verify) Run(evm *EVM, input []byte) ([]byte, error) {
 	x, y := new(big.Int).SetBytes(input[96:128]), new(big.Int).SetBytes(input[128:160])
 
 	// Verify the secp256r1 signature
-	if secp256r1.Verify(hash, r, s, x, y) {
-		// Signature is valid
-		return common.LeftPadBytes([]byte{1}, 32), nil
-	} else {
-		// Signature is invalid
+	ret, err := secp256r1.Verify(hash, r, s, x, y)
+	// Signature is invalid
+	if err != nil {
+		log.Info("secp256r1 signature verification failed", "error", err)
 		return nil, nil
 	}
+	// Signature is valid
+	return ret, nil
 }

--- a/crypto/secp256r1/verifier_test.go
+++ b/crypto/secp256r1/verifier_test.go
@@ -1,0 +1,79 @@
+package secp256r1
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"math/big"
+	"testing"
+)
+
+func prepareSignatureTest() (*ecdsa.PrivateKey, []byte, [32]byte, *big.Int, *big.Int, error) {
+	// Generate a new private key using P-256 curve
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, [32]byte{}, nil, nil, fmt.Errorf("error generating private key: %w", err)
+	}
+
+	// Message to be signed
+	message := []byte("xyz")
+
+	// Hash the message using SHA-256
+	hash := sha256.Sum256(message)
+
+	// Sign the hash using the private key
+	r, s, err := ecdsa.Sign(rand.Reader, privateKey, hash[:])
+	if err != nil {
+		return nil, nil, [32]byte{}, nil, nil, fmt.Errorf("error signing message: %w", err)
+	}
+
+	return privateKey, message, hash, r, s, nil
+}
+
+func TestVerifySignatureMalleable_ValidSignature(t *testing.T) {
+	privateKey, _, hash, r, s, err := prepareSignatureTest()
+	if err != nil {
+		t.Fatalf("Preparation failed: %v", err)
+	}
+
+	x := privateKey.PublicKey.X
+	y := privateKey.PublicKey.Y
+	nCurve := elliptic.P256().Params().N
+
+	// make sure s is less than half of the curve order to simulate normalization
+	sPrime := new(big.Int).Sub(nCurve, s)
+	if sPrime.Cmp(s) == -1 {
+		s = sPrime
+	}
+
+	_, err = Verify(hash[:], r, s, x, y)
+	if err != nil {
+		t.Fatalf("Error verifying original signature: %v", err)
+	}
+}
+
+func TestVerifySignatureMalleable_InvalidSignature(t *testing.T) {
+	privateKey, _, hash, r, s, err := prepareSignatureTest()
+	if err != nil {
+		t.Fatalf("Preparation failed: %v", err)
+	}
+
+	x := privateKey.PublicKey.X
+	y := privateKey.PublicKey.Y
+
+	// Get the curve order n
+	nCurve := elliptic.P256().Params().N
+
+	// make sure s is bigger than half of the curve order to simulate lack of normalization
+	sPrime := new(big.Int).Sub(nCurve, s)
+	if sPrime.Cmp(s) == 1 {
+		s = sPrime
+	}
+
+	_, err = Verify(hash[:], r, s, x, y)
+	if err == nil {
+		t.Fatalf("Malleable signature should not be verified")
+	}
+}


### PR DESCRIPTION
The new malleability check might return an error.
But to maintain consistency with the previous check logic, the error will not be propagated to the upper-level caller and will instead output a log and return `nil, nil`.