### PR TITLE
Fix: Mitigate unbounded log growth and prevent duplicate log entries

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -293,6 +293,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 
 	// Initialize the guardian module
 	guardian.InitInstance(config.Guardian)
+	guardian.InitFilteredReport(config.Guardian)
 
 	// Start the RPC service
 	eth.netRPCService = ethapi.NewNetAPI(eth.p2pServer, networkID)

--- a/guardian/guardian.go
+++ b/guardian/guardian.go
@@ -145,9 +145,7 @@ func (p *Guardian) checkAddress(tx *types.Transaction, from, addr string) (bool,
 		return false, err
 	}
 	if ok {
-		if err := logFilteredEntry(filteredTxLog{filteredAddress: addr, from: from, transaction: tx}); err != nil {
-			log.Error("Failed to log filtered transaction", "err", err)
-		}
+		logFilteredEntry(filteredTxLog{filteredAddress: addr, from: from, transaction: tx})
 		log.Warn("Filtered address found in transaction", "tx", tx.Hash().Hex(), "address", addr)
 		return true, nil
 	}

--- a/guardian/guardian_test.go
+++ b/guardian/guardian_test.go
@@ -162,10 +162,12 @@ func testInitInstance(t *testing.T, enabled bool, testFromAddress string) {
 	filterFilePath := testSaveBloomFilterToFile(t, bf)
 	defer os.Remove(filterFilePath)
 
-	InitInstance(Config{
+	conf := Config{
 		Enabled:        enabled,
 		FilterFilePath: filterFilePath,
-	})
+	}
+	InitInstance(conf)
+	InitFilteredReport(conf)
 }
 
 func testSaveBloomFilterToFile(t *testing.T, bf *store.BloomFilterStore) string {


### PR DESCRIPTION
- Implemented `filteredCache` using `sync.Map` to avoid outputting duplicate sanctioned address logs.
- Use `chan` to avoid I/O performance issues and potential file lock contention.