### PR TITLE
feat(params): use default denom for aeneid

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -879,6 +879,10 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, headNumber *big.Int, 
 // BaseFeeChangeDenominator bounds the amount the base fee can change between blocks.
 func (c *ChainConfig) BaseFeeChangeDenominator() uint64 {
 	if c.IsStory() {
+		// For Iliad and Aeneid, use the DefaultBaseFeeChangeDenominator.
+		if c.IsIliad() || c.IsAeneid() {
+			return DefaultBaseFeeChangeDenominator
+		}
 		return DefaultBaseFeeChangeDenomStory
 	}
 
@@ -902,6 +906,14 @@ func (c *ChainConfig) IsStory() bool {
 		chainId == IDStoryOdyssey ||
 		chainId == IDStoryIliad ||
 		chainId == IDStoryLocal
+}
+
+func (c *ChainConfig) IsIliad() bool {
+	return c.ChainID.Uint64() == IDStoryIliad
+}
+
+func (c *ChainConfig) IsAeneid() bool {
+	return c.ChainID.Uint64() == IDStoryAeneid
 }
 
 // LatestFork returns the latest time-based fork that would be active for the given time.


### PR DESCRIPTION
As seen [here](https://github.com/piplabs/story-geth/pull/94/files#diff-10ff00a15ef58da7485fedeca3906c73cb236fde4b143a9d61601c63cbf1ffe8R901), the Aeneid was not included in Story, so default value of EIP1559 denominator, 8, was used for Aeneid. 