### PR TITLE
feat(*): remove min priority fee restriction

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1936,7 +1936,6 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		}
 		cfg.Genesis = core.DefaultAeneidGenesisBlock()
 		SetDNSDiscoveryDefaults(cfg, params.AeneidGenesisHash)
-		cfg.Miner.GasPrice = big.NewInt(params.GWei * 4)
 		cfg.Miner.GasCeil = 36_000_000
 		cfg.TxPool.NoLocals = true
 	case ctx.Bool(StoryFlag.Name):
@@ -1945,7 +1944,6 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		}
 		cfg.Genesis = core.DefaultStoryGenesisBlock()
 		SetDNSDiscoveryDefaults(cfg, params.StoryGenesisHash)
-		cfg.Miner.GasPrice = big.NewInt(params.GWei * 4)
 		cfg.Miner.GasCeil = 36_000_000
 		cfg.TxPool.NoLocals = true
 	case ctx.Bool(LocalFlag.Name):


### PR DESCRIPTION
Gas price determines the minimum priority fee that users need to pay. The higher minimum priority fee confuses users when they don't set a high enough priority fee. Adjust it back to default to be compatible with Ethereum toolings