### PR TITLE
params: replace Aeneid bootnode config

### DIFF
--- a/.github/workflows/ci-s3.yml
+++ b/.github/workflows/ci-s3.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Extract the version
         run: |
-          PARAMS_FILE="./params/version.go"
+          PARAMS_FILE="./version/version.go"
           VERSION_MAJOR=$(awk -F= '/VersionMajor/ {gsub(/[^0-9]/, "", $2); printf "%s", $2}' $PARAMS_FILE)
           VERSION_MINOR=$(awk -F= '/VersionMinor/ {gsub(/[^0-9]/, "", $2); printf "%s", $2}' $PARAMS_FILE)
           VERSION_PATCH=$(awk -F= '/VersionPatch/ {gsub(/[^0-9]/, "", $2); printf "%s", $2}' $PARAMS_FILE)

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -4046,7 +4046,8 @@ func TestPragueRequests(t *testing.T) {
 	if rh == nil {
 		t.Fatal("block has nil requests hash")
 	}
-	expectedRequestsHash := common.HexToHash("0x06ffb72b9f0823510b128bca6cd4f96f59b745de6791e9fc350b596e7605101e")
+	// Due to omit of EIP-7002, EIP-7251 and EIP-6110, the hash differs from the origin one.
+	expectedRequestsHash := common.HexToHash("0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
 	if *rh != expectedRequestsHash {
 		t.Fatalf("block has wrong requestsHash %v, want %v", *rh, expectedRequestsHash)
 	}

--- a/eth/protocols/eth/handler_test.go
+++ b/eth/protocols/eth/handler_test.go
@@ -624,9 +624,10 @@ func FuzzEthProtocolHandlers(f *testing.F) {
 }
 
 func TestGetPooledTransaction(t *testing.T) {
-	t.Run("blobTx", func(t *testing.T) {
-		testGetPooledTransaction(t, true)
-	})
+	// Not supporting blob transactions yet
+	// t.Run("blobTx", func(t *testing.T) {
+	// 	testGetPooledTransaction(t, true)
+	// })
 	t.Run("legacyTx", func(t *testing.T) {
 		testGetPooledTransaction(t, false)
 	})

--- a/params/bootnodes.go
+++ b/params/bootnodes.go
@@ -79,7 +79,7 @@ var OdysseyBootnodes = []string{
 // Aeneid testnet network.
 var AeneidBootnodes = []string{
 	// Upstream bootnodes
-	"enode://a7e893eb4b07bd9b0c0659730c066564dff0f5fa98c08a7df9f380b84e64fbea16165ee5cce6c3414d64bea8cacc1ac200540c50607a7bf170b9d5504f81bbf8@b1-b.odyssey-devnet.storyrpc.io:30303",
+	"enode://a7e893eb4b07bd9b0c0659730c066564dff0f5fa98c08a7df9f380b84e64fbea16165ee5cce6c3414d64bea8cacc1ac200540c50607a7bf170b9d5504f81bbf8@35.211.57.203:30303",
 }
 
 // StoryBootnodes are the enode URLs of the P2P bootstrap nodes running on the


### PR DESCRIPTION
1. Replace the domain name at the end of the enode URL with its corresponding IP address to avoid bootnode parsing failure.
2. Fix unit test failures caused by omitted execution requests and unsupported blob transactions.
3. Resolve workflow failures resulting from the updated path of version.go.