### PR TITLE
Dockerfile: change go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.23-alpine as builder
+FROM golang:1.24.10-alpine AS builder
 
 RUN apk add --no-cache gcc musl-dev linux-headers git
 


### PR DESCRIPTION
change go version to 1.24.10

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrades the Docker build toolchain.
> 
> - Updates Dockerfile builder image from `golang:1.23-alpine` to `golang:1.24.10-alpine`; no changes to build steps or runtime stage
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b08b475c628ed036516bf7cf465bbcac0f32ba60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->