### PR TITLE
p2p: add DNS resolution for bootnodes

### DIFF
--- a/p2p/enode/urlv4_test.go
+++ b/p2p/enode/urlv4_test.go
@@ -87,6 +87,15 @@ var parseNodeTests = []struct {
 		).WithHostname("valid."),
 	},
 	{
+		input: "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@invalid.:3",
+		wantResult: NewV4(
+			hexPubkey("1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439"),
+			nil,
+			3,
+			3,
+		).WithHostname("invalid."),
+	},
+	{
 		input: "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@[::]:52150",
 		wantResult: NewV4(
 			hexPubkey("1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439"),

--- a/params/bootnodes.go
+++ b/params/bootnodes.go
@@ -79,16 +79,15 @@ var OdysseyBootnodes = []string{
 // Aeneid testnet network.
 var AeneidBootnodes = []string{
 	// Upstream bootnodes
-	"enode://a7e893eb4b07bd9b0c0659730c066564dff0f5fa98c08a7df9f380b84e64fbea16165ee5cce6c3414d64bea8cacc1ac200540c50607a7bf170b9d5504f81bbf8@35.211.57.203:30303",
+	"enode://a7e893eb4b07bd9b0c0659730c066564dff0f5fa98c08a7df9f380b84e64fbea16165ee5cce6c3414d64bea8cacc1ac200540c50607a7bf170b9d5504f81bbf8@b1-b.odyssey-devnet.storyrpc.io:30303",
 }
 
 // StoryBootnodes are the enode URLs of the P2P bootstrap nodes running on the
 // Story main network.
 var StoryBootnodes = []string{
 	// Upstream bootnodes
-	// TODO: update bootnodes for mainnet
-	"enode://f42110982b6ddaa4de8031f9fecb619d181902db5529a43bc9b1187debbc67771bf937b2210cbfd33babd2acbe138506596e23d0d1792ab3cb5229c5bb051544@35.211.238.157:30303",
-	"enode://2ae459a7cc28b59822377deec266e24e5ed00374d7a83e2e8d0d67dd89dc2b80366c1353c7909fe81b840f6081188850677fa20dd5d262c9e3f67eb23d0be0b5@35.211.209.170:30303",
+	"enode://f42110982b6ddaa4de8031f9fecb619d181902db5529a43bc9b1187debbc67771bf937b2210cbfd33babd2acbe138506596e23d0d1792ab3cb5229c5bb051544@b1.storyrpc.io:30303",
+	"enode://2ae459a7cc28b59822377deec266e24e5ed00374d7a83e2e8d0d67dd89dc2b80366c1353c7909fe81b840f6081188850677fa20dd5d262c9e3f67eb23d0be0b5@b2.storyrpc.io:30303",
 }
 
 var V5Bootnodes = []string{


### PR DESCRIPTION
In the [upstream PR](https://github.com/ethereum/go-ethereum/pull/30822)
, DNS resolution was moved from parse time to dial time to better support containerized environments. This change works correctly for static peers. However, bootnodes are subject to an additional pre-dial check, which can fail when a bootnode is specified using a domain name rather than a raw IP address. [An issue](https://github.com/ethereum/go-ethereum/issues/31208) was created for go-ethereum.

To address this, op-geth introduced a [PR](https://github.com/ethereum-optimism/op-geth/pull/531)
 that re-adds DNS resolution at parse time. While this fixes the bootnode issue, it also changes the behavior for static peers: DNS resolution is effectively performed twice—once during parsing and again during dialing—which is undesirable.

In this PR, DNS resolution is performed **AFTER** parsing and before dialing, and only for bootnodes. This avoids the double-resolution issue and ensures that the behavior of static peers and other peer types remains unchanged.