### PR TITLE
.github/workflows: pin docker action shas and add gha cache permission

### DIFF
--- a/.github/workflows/push-ghcr.yml
+++ b/.github/workflows/push-ghcr.yml
@@ -15,6 +15,7 @@ jobs:
   build_and_push:
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: read
       packages: write
 

--- a/.github/workflows/push-ghcr.yml
+++ b/.github/workflows/push-ghcr.yml
@@ -34,10 +34,10 @@ jobs:
           echo "BUILDNUM=${{ github.run_number }}" >> $GITHUB_ENV
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/push-ghcr.yml
+++ b/.github/workflows/push-ghcr.yml
@@ -55,8 +55,8 @@ jobs:
             -t $REPOSITORY_URI:latest \
             -t $REPOSITORY_URI:$COMMIT \
             -t $REPOSITORY_URI:$VERSION \
-            --cache-from=type=local,src=/tmp/.buildx-cache \
-            --cache-to=type=local,dest=/tmp/.buildx-cache \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
             --push \
             -f ./Dockerfile \
             . 


### PR DESCRIPTION
## Summary

- Switch buildx cache from `type=local` to `type=gha` with `mode=max`

Local cache (`/tmp/.buildx-cache`) doesn't persist across GitHub Actions runs, so every build starts cold. GHA cache backend uses GitHub's built-in cache service for actual cache hits.